### PR TITLE
VariablePkg: Add initial package

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -1,0 +1,200 @@
+# @file
+#
+# Defines the CI settings for the Project Mu UEFI variable repository.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import os
+import logging
+from edk2toolext.environment import shell_environment
+from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
+from edk2toolext.invocables.edk2_ci_setup import CiSetupSettingsManager
+from edk2toolext.invocables.edk2_update import UpdateSettingsManager
+from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
+from edk2toollib.utility_functions import GetHostInfo
+
+
+class Settings(
+        CiSetupSettingsManager,
+        CiBuildSettingsManager,
+        UpdateSettingsManager,
+        PrEvalSettingsManager):
+
+    def __init__(self):
+        self.actual_packages = []
+        self.actual_targets = []
+        self.actual_architectures = []
+        self.actual_tool_chain_tag = ""
+        self.use_built_in_base_tools = None
+        self.actual_scopes = None
+
+    # ###################################################################### #
+    #                             Extra CmdLine configuration                #
+    # ###################################################################### #
+
+    def AddCommandLineOptions(self, parserObj):
+        pass
+
+    def RetrieveCommandLineOptions(self, args):
+        pass
+
+    # ###################################################################### #
+    #                        Default Support for this Ci Build               #
+    # ###################################################################### #
+
+    def GetPackagesSupported(self):
+        """return iterable of edk2 packages supported by this build.
+        These should be edk2 workspace relative paths."""
+
+        return ("VariablePkg",)
+
+    def GetArchitecturesSupported(self):
+        """return iterable of edk2 architectures supported by this build."""
+
+        return ("IA32", "X64", "ARM", "AARCH64")
+
+    def GetTargetsSupported(self):
+        """return iterable of edk2 target tags supported by this build."""
+
+        return ("DEBUG", "RELEASE", "NO-TARGET", "NOOPT")
+
+    # ###################################################################### #
+    #                     Verify and Save requested Ci Build Config          #
+    # ###################################################################### #
+
+    def SetPackages(self, list_of_requested_packages):
+        """
+        Confirm the requested package list is valid and configure
+        SettingsManager to build the requested packages.
+
+        Raises an exception if a requested package is not supported.
+        """
+
+        unsupported = (set(list_of_requested_packages) -
+                       set(self.GetPackagesSupported()))
+
+        if len(unsupported) > 0:
+            logging.critical("Unsupported Package Requested: "
+                             " ".join(unsupported))
+            raise Exception("Unsupported Package Requested: "
+                            " ".join(unsupported))
+
+        self.actual_packages = list_of_requested_packages
+
+    def SetArchitectures(self, list_of_requested_architectures):
+        """Confirm the requests architecture list is valid and configure
+        SettingsManager to run only the requested architectures.
+
+        Raises an exception if a requested architeecture is not supported.
+        """
+
+        unsupported = (set(list_of_requested_architectures) -
+                       set(self.GetArchitecturesSupported()))
+
+        if len(unsupported) > 0:
+            logging.critical(
+                "Unsupported Architecture Requested: " + " ".join(unsupported))
+            raise Exception(
+                "Unsupported Architecture Requested: " + " ".join(unsupported))
+        self.actual_architectures = list_of_requested_architectures
+
+    def SetTargets(self, list_of_requested_target):
+        """Confirm the request target list is valid and configure
+        SettingsManager to run only the requested targets.
+
+        Raise an exception if a requested target is not supported.
+        """
+
+        unsupported = (set(list_of_requested_target) -
+                       set(self.GetTargetsSupported()))
+
+        if len(unsupported) > 0:
+            logging.critical("Unsupported Targets Requested: "
+                             " ".join(unsupported))
+            raise Exception("Unsupported Targets Requested: "
+                            " ".join(unsupported))
+        self.actual_targets = list_of_requested_target
+
+    # ###################################################################### #
+    #                         Actual Configuration for Ci Build              #
+    # ###################################################################### #
+
+    def GetActiveScopes(self):
+        """
+        Return a tuple containing scopes that should be active for this
+        process.
+        """
+
+        scopes = ("feature-variable-ci",
+                  "cibuild",
+                  "edk2-build",
+                  "host-based-test")
+
+        self.ActualToolChainTag = \
+            shell_environment.GetBuildVars().GetValue("TOOL_CHAIN_TAG", "")
+
+        if GetHostInfo().os.upper() == "LINUX" and \
+           self.ActualToolChainTag.upper().startswith("GCC"):
+            if "AARCH64" in self.ActualArchitectures:
+                scopes += ("gcc_aarch64_linux",)
+            if "ARM" in self.ActualArchitectures:
+                scopes += ("gcc_arm_linux",)
+            if "RISCV64" in self.ActualArchitectures:
+                scopes += ("gcc_riscv64_unknown",)
+
+        return scopes
+
+    def GetRequiredSubmodules(self):
+        """
+        Return an iterable containing RequiredSubmodule objects. If there are
+        no RequiredSubmodules, then return an empty iterable.
+        """
+
+        return []
+
+    def GetName(self):
+        """Returns the CI name."""
+
+        return "MuUefiVariables"
+
+    def GetDependencies(self):
+        """
+        Return git repository dependencies.
+
+        Return san iterable of dictionary objects with the following fields:
+        {
+            Path: <required> Workspace relative path
+            Url: <required> Url of git repo
+            Commit: <optional> Commit to checkout of repo
+            Branch: <optional> Branch to checkout (will checkout most recent
+                    commit in branch)
+            Full: <optional> Boolean to do shallow or Full checkout.
+                  (default is False)
+            ReferencePath: <optional> Workspace relative path to git repo to
+                           use as "reference"
+        }
+        """
+
+        return []
+
+    def GetPackagesPath(self):
+        """
+        Return a list of workspace relative paths that should be mapped as
+        an edk2 packages path.
+        """
+
+        result = [
+            shell_environment.GetBuildVars().GetValue("MU_BASECORE_PATH", ""),
+            shell_environment.GetBuildVars().GetValue("MU_PLUS_PATH", ""),
+            shell_environment.GetBuildVars().GetValue("MU_TIANO_PATH", ""),
+        ]
+        for a in self.GetDependencies():
+            result.append(a["Path"])
+        return result
+
+    def GetWorkspaceRoot(self):
+        """Returns the workspace root directory path."""
+
+        return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/VariablePkg/VariablePkg.ci.yaml
+++ b/VariablePkg/VariablePkg.ci.yaml
@@ -1,0 +1,75 @@
+##
+# CI configuration for VariablePkg
+#
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    ## options defined ci/Plugin/CompilerPlugin
+    "CompilerPlugin": {
+        "DscPath": "VariablePkg.dsc"
+    },
+
+    ## options defined ci/Plugin/CharEncodingCheck
+    "CharEncodingCheck": {
+        "IgnoreFiles": []
+    },
+
+    ## options defined ci/Plugin/DependencyCheck
+    "DependencyCheck": {
+        "AcceptableDependencies": [
+            "MdePkg/MdePkg.dec",
+            "MdeModulePkg/MdeModulePkg.dec"
+        ],
+        "AcceptableDependencies-HOST_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
+        "AcceptableDependencies-UEFI_APPLICATION": [
+            "ShellPkg/ShellPkg.dec",
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
+        "IgnoreInf": []
+    },
+
+    ## options defined ci/Plugin/DscCompleteCheck
+    "DscCompleteCheck": {
+        "IgnoreInf": [],
+        "DscPath": "VariablePkg.dsc"
+    },
+
+    ## options defined ci/Plugin/HostUnitTestCompilerPlugin
+    "HostUnitTestCompilerPlugin": {
+        ""
+        # Todo: Uncomment when host tests are added # "DscPath": "Test/VariablePkgHostTest.dsc"
+    },
+
+    ## options defined ci/Plugin/GuidCheck
+    "GuidCheck": {
+        "IgnoreGuidName": [],
+        "IgnoreGuidValue": [],
+        "IgnoreFoldersAndFiles": [],
+        "IgnoreDuplicates": []
+    },
+
+    ## options defined ci/Plugin/HostUnitTestDscCompleteCheck
+    "HostUnitTestDscCompleteCheck": {
+        "IgnoreInf": [""],
+        "DscPath": ""
+        # Todo: Uncomment when host tests are added # "DscPath": "Test/VariablePkgHostTest.dsc"
+    },
+
+    ## options defined ci/Plugin/LibraryClassCheck
+    "LibraryClassCheck": {
+        "IgnoreLibraryClass": [],
+        "IgnoreHeaderFile": []
+    },
+
+    ## options defined ci/Plugin/SpellCheck
+    "SpellCheck": {
+        "AuditOnly": False,
+        "IgnoreFiles": [],
+        "IgnoreStandardPaths": [],
+        "AdditionalIncludePaths": [],
+        "ExtendWords": []
+    }
+}

--- a/VariablePkg/VariablePkg.dec
+++ b/VariablePkg/VariablePkg.dec
@@ -1,0 +1,15 @@
+## @file
+# Build declaration file for VariablePkg
+#
+# This package contains a modern and extensible UEFI variable implementation.
+#
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  DEC_SPECIFICATION = 0x00010017
+  PACKAGE_NAME      = VariablePkg
+  PACKAGE_VERSION   = 0.1
+  PACKAGE_GUID      = F5CBF62A-9B10-427B-B6F9-762C0FA6F544

--- a/VariablePkg/VariablePkg.dsc
+++ b/VariablePkg/VariablePkg.dsc
@@ -1,0 +1,19 @@
+## @file
+# Build description file for VariablePkg
+#
+# This package contains a modern and extensible UEFI variable implementation.
+#
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME                  = VariablePkg
+  PLATFORM_GUID                  = B7F54706-4F42-4D9E-ABDB-924170A69F84
+  PLATFORM_VERSION               = 0.1
+  DSC_SPECIFICATION              = 0x0001001C
+  OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
+  SUPPORTED_ARCHITECTURES        = IA32|X64|ARM|AARCH64
+  BUILD_TARGETS                  = DEBUG|RELEASE
+  SKUID_IDENTIFIER               = DEFAULT


### PR DESCRIPTION
## Description

Closes #5 

Adds an empty package that builds successfully.

This provides a foundation for future code changes and allows CI to be put in place around the build.

## How This Was Tested

1. Verified the following commands return successfully:
   1. `stuart_ci_setup -c .pytool/CISettings.py`
   2. `stuart_update -c .pytool/CISettings.py`
   3. `stuart_ci_build -c .pytool/CISettings.py`
   4. `stuart_update -c .pytool/CISettings.py -p VariablePkg`
2. Verified build with `build` command: `build -p VariablePkg -a IA32 -a X64 -t VS2022`

## Integration Instructions

`VariablePkg` can be brought into a consumer repo as a dependency now but that is not very
useful as the package is not populated yet.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>