### PR TITLE
Add GitHub CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,27 @@
+## @file
+# Project Mu UEFI Variables CodeQL file.
+#
+# Triggers the CodeQL GitHub action flow on the main branch.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 2 * * 4'
+
+jobs:
+  codeql-analysis:
+    uses: microsoft/mu_devops/.github/workflows/CodeQl.yml@main
+    with:
+      update_command: stuart_update -c .pytool/CISettings.py -p VariablePkg -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=GCC5
+      build_command: stuart_ci_build -c .pytool/CISettings.py -p VariablePkg -t DEBUG -a IA32,X64 TOOL_CHAIN_TAG=GCC5
+


### PR DESCRIPTION
## Description

Closes #21

Adds a CodeQL workflow that leverages the reusable workflow template in mu_devops.

## How This Was Tested

1. Verified template is functional in mu_devops repo
2. Verified build command is correct in this repo's YAML file

## Integration Instructions

N/A - No downstream integration needed

After this change is enabled, view the `Actions` tab to see the CodeQL results.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>