### PR TITLE
Remove pull_request trigger for add-to-project GitHub action

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -4,11 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
-# Temporary change to check project automation results
 jobs:
   add-to-project:
     name: Add item to GitHub project
@@ -17,4 +13,4 @@ jobs:
       - uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/microsoft/projects/479
-          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || project_auto_fall_back_to_built_in_token }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/microsoft/projects/479
-          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || project_auto_fall_back_to_built_in_token }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,6 +8,7 @@ on:
     types:
       - opened
 
+# Temporary change to check project automation results
 jobs:
   add-to-project:
     name: Add item to GitHub project


### PR DESCRIPTION
## Description

Closes #32 

Since GitHub treats workflows triggered from forks (and Dependabot) as
untrusted, they receive a read-only GITHUB_TOKEN and the PRs cannot
access any secrets in the repository.

A secret token is required with project write access for the add-to-project
action to automatically assign issues and PRs to a project.

More information:
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

The trigger type could be changed to `pull_request_target` which would
grant permission to the secret token:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

But that has security implications as described here:
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

In the end, we'll just remove the action for pull requests for now and only have
issues automatically get assigned to the project upon creation.

## How This Was Tested

Verified actions/add-to-project no longer triggers on pull requests.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>